### PR TITLE
Patched Server-Side Request Forgery in parse-url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2429,7 +2429,7 @@
       "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
       "requires": {
         "is-ssh": "^1.3.0",
-        "parse-url": "^5.0.0"
+        "parse-url": "^6.0.1"
       }
     },
     "git-url-parse": {
@@ -5761,8 +5761,8 @@
       }
     },
     "parse-url": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.1.tgz",
       "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
       "requires": {
         "is-ssh": "^1.3.0",


### PR DESCRIPTION
Server-Side Request Forgery (SSRF) in GitHub repository ionicabizau/parse-url prior to 7.0.0.

**CVE-2022-2216**
``9.8/ 10``