### PR TITLE
Patched Remote code execution in handlebars when compiling templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4051,7 +4051,7 @@
             "escodegen": "1.8.x",
             "esprima": "2.7.x",
             "fileset": "0.2.x",
-            "handlebars": "^4.0.1",
+            "handlebars": "^4.7.7",
             "js-yaml": "3.x",
             "mkdirp": "0.5.x",
             "nopt": "3.x",


### PR DESCRIPTION
The package handlebars before 4.7.7 are vulnerable to Remote Code Execution (RCE) when selecting certain compiling options to compile templates coming from an untrusted source.

**CVE-2021-23369**
``9.8/ 10``