### PR TITLE
Pached remote code execution due to weak input validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,8 +1819,8 @@
       "integrity": "sha1-jJshKJjYzZ8alDZlDOe+ICyen/A="
     },
     "ejs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-1.0.0.tgz",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
       "integrity": "sha1-ycYKSKRu5FL7MqccMXuV5aofyz0="
     },
     "ejs-locals": {


### PR DESCRIPTION
nodejs ejs versions older than 2.5.3 is vulnerable to remote code execution due to weak input validation in ejs.renderFile() function

**CVE-2017-1000228**
``9.8/ 10``